### PR TITLE
ci: implement ci status notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
 
       - uses: technote-space/workflow-conclusion-action@v2.0.1
       
-      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+      - uses: reside-eng/workflow-status-notification-action@v1.0.0
         with:
           current-status: ${{ env.WORKFLOW_CONCLUSION }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,32 +80,19 @@ jobs:
         run: |
           git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/v${{steps.semantic.outputs.new_release_major_version}}
 
-  success-notification:
-    if: success()
-    name: success-notification
+  notification:
+    if: always()
+    name: notification
     needs: [publish]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.3.4
 
+      - uses: technote-space/workflow-conclusion-action@v2.0.1
+      
       - uses: reside-eng/workflow-status-slack-notification@v1.0.0
         with:
-          current-status: 'success'
-          slack-webhook: '${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}'
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-
-  failure-notification:
-    if: failure()
-    name: failure-notification
-    needs: [publish]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2.3.4
-
-      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
-        with:
-          current-status: 'failure'
-          slack-webhook: '${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}'
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          current-status: ${{ env.WORKFLOW_CONCLUSION }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,3 +79,33 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/v${{steps.semantic.outputs.new_release_major_version}}
+
+  success-notification:
+    if: success()
+    name: success-notification
+    needs: [publish]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.4
+
+      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+        with:
+          current-status: 'success'
+          slack-webhook: '${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+  failure-notification:
+    if: failure()
+    name: failure-notification
+    needs: [publish]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.4
+
+      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+        with:
+          current-status: 'failure'
+          slack-webhook: '${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/verify-dependabot.yml
+++ b/.github/workflows/verify-dependabot.yml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: technote-space/workflow-conclusion-action@v2.0.1
       
-      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+      - uses: reside-eng/workflow-status-notification-action@v1.0.0
         with:
           current-status: ${{ env.WORKFLOW_CONCLUSION }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}

--- a/.github/workflows/verify-dependabot.yml
+++ b/.github/workflows/verify-dependabot.yml
@@ -60,32 +60,19 @@ jobs:
       - name: Build
         run: yarn build
 
-  success-notification:
-    if: success() && github.actor == 'dependabot[bot]'
-    name: success-notification
+  notification:
+    if: always() && github.actor == 'dependabot[bot]'
+    name: notification
     needs: [build]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.3.4
 
+      - uses: technote-space/workflow-conclusion-action@v2.0.1
+      
       - uses: reside-eng/workflow-status-slack-notification@v1.0.0
         with:
-          current-status: 'success'
-          slack-webhook: '${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}'
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-
-  failure-notification:
-    if: failure() && github.actor == 'dependabot[bot]'
-    name: failure-notification
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2.3.4
-
-      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
-        with:
-          current-status: 'failure'
-          slack-webhook: '${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}'
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          current-status: ${{ env.WORKFLOW_CONCLUSION }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify-dependabot.yml
+++ b/.github/workflows/verify-dependabot.yml
@@ -22,10 +22,6 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      #TMP: for test purpose
-      - name: Test failure notif
-        run: |
-          exit 3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2.4.0

--- a/.github/workflows/verify-dependabot.yml
+++ b/.github/workflows/verify-dependabot.yml
@@ -59,3 +59,33 @@ jobs:
 
       - name: Build
         run: yarn build
+
+  success-notification:
+    if: success() && github.actor == 'dependabot[bot]'
+    name: success-notification
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.4
+
+      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+        with:
+          current-status: 'success'
+          slack-webhook: '${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+  failure-notification:
+    if: failure() && github.actor == 'dependabot[bot]'
+    name: failure-notification
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.4
+
+      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+        with:
+          current-status: 'failure'
+          slack-webhook: '${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/verify-dependabot.yml
+++ b/.github/workflows/verify-dependabot.yml
@@ -22,6 +22,10 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      #TMP: for test purpose
+      - name: Test failure notif
+        run: |
+          exit 3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2.4.0

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,10 +17,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.3.4
-      #TMP: for test purpose
-      - name: Test failure notif
-        run: |
-          exit 3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2.4.0

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -54,3 +54,33 @@ jobs:
 
       - name: Build
         run: yarn build
+
+  success-notification:
+    if: success() && github.actor != 'dependabot[bot]'
+    name: success-notification
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.4
+
+      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+        with:
+          current-status: 'success'
+          slack-webhook: '${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+  failure-notification:
+    if: failure() && github.actor != 'dependabot[bot]'
+    name: failure-notification
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.4
+
+      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+        with:
+          current-status: 'failure'
+          slack-webhook: '${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.3.4
+      #TMP: for test purpose
+      - name: Test failure notif
+        run: |
+          exit 3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2.4.0

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -55,32 +55,19 @@ jobs:
       - name: Build
         run: yarn build
 
-  success-notification:
-    if: success() && github.actor != 'dependabot[bot]'
-    name: success-notification
+  notification:
+    if: always() && github.actor != 'dependabot[bot]'
+    name: notification
     needs: [build]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.3.4
 
+      - uses: technote-space/workflow-conclusion-action@v2.0.1
+      
       - uses: reside-eng/workflow-status-slack-notification@v1.0.0
         with:
-          current-status: 'success'
-          slack-webhook: '${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}'
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-
-  failure-notification:
-    if: failure() && github.actor != 'dependabot[bot]'
-    name: failure-notification
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2.3.4
-
-      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
-        with:
-          current-status: 'failure'
-          slack-webhook: '${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}'
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          current-status: ${{ env.WORKFLOW_CONCLUSION }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -66,7 +66,7 @@ jobs:
 
       - uses: technote-space/workflow-conclusion-action@v2.0.1
       
-      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+      - uses: reside-eng/workflow-status-notification-action@v1.0.0
         with:
           current-status: ${{ env.WORKFLOW_CONCLUSION }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}


### PR DESCRIPTION
Use of our new Github custom action for CI success/failure slack notifications (workflow-status-slack-notification).
For each branch/PR we'll be notified if:
- A workflow is failing for the first time (failure notification)
- A workflow is failing and previous attempt was successful (failure notification)
- A workflow is succeeding and previous attempt was failed (success notification)
We'll not be notified if:
- A workflow is succeeding and previous attempt was successful (or it is the first run)
- A workflow is failing and previous attempt was failed (notification already sent on the first failed attempt)

This works for new commits triggering a workflow but also when re-running the same workflow thanks to the github workflow cache feature.

We specify the slack channel we want to send the notification to with a webhook specified as a secret.
This webhook is specific to a channel and can be created/retrieved here: https://api.slack.com/apps/A02N76U245V/incoming-webhooks?

We could create a specific channel/webhook for each repository.
We could use an existing channel/webhook for each repository.
We could have a general/common channel/webhook for CI status for all repositories.

For this repo we're going to use:
- `SLACK_WEBHOOK_PLATFORM_PROD` for all our workflows
note: currently all platform alerts (all environments) are going to eng-platform-alerts, if at some point we want to have different channels for prod/non-prod related workflows alerts, we could do as for core and have two different channels/webhooks.

Currently we can only specify one channel/webhook but if we have the need to send notifications to multiple channel/webhook, it would be easy to add this capability to our custom action, so don't hesitate.

Don't hesitate if you have any comment/question.