### PR TITLE
chore: rename action to workflow-status-notification-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Push updates to branch for major version
         # If a new version is published, i.e. v1.2.3 then this step will update
         # branch "v1" to this commit.
-        # https://github.com/reside-eng/workflow-status-slack-notification/branches
+        # https://github.com/reside-eng/workflow-status-notification-action/branches
         if: steps.semantic.outputs.new_release_published == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ YOUR_SLACK_WEBHOOK: Webhook URL from Slack Incoming Webhook application
 <!-- start usage -->
 <!-- Warning: Content between these comments is auto-generated. Do NOT manually edit. -->
 ```yaml
-- uses: reside-eng/workflow-status-slack-notification@v1
+- uses: reside-eng/workflow-status-notification-action@v1
   with:
     # Status of the current run
     #
@@ -83,7 +83,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2.3.4
 
-      - uses: reside-eng/workflow-status-slack-notification@v1.0.7
+      - uses: reside-eng/workflow-status-notification-action@v1.0.7
         with:
           current-status: "success"
           slack-webhook: "${{ secrets.YOUR_SLACK_WEBHOOK }}"
@@ -98,7 +98,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2.3.4
 
-      - uses: reside-eng/workflow-status-slack-notification@v1.0.7
+      - uses: reside-eng/workflow-status-notification-action@v1.0.7
         with:
           current-status: "failure"
           slack-webhook: "${{ secrets.YOUR_SLACK_WEBHOOK }}"

--- a/bin/generate-docs.ts
+++ b/bin/generate-docs.ts
@@ -144,4 +144,4 @@ function updateUsage(
   fs.writeFileSync(readmePath, newReadme.join(os.EOL));
 }
 
-updateUsage('reside-eng/workflow-status-slack-notification@v1');
+updateUsage('reside-eng/workflow-status-notification-action@v1');

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@side/workflow-status-slack-notification",
+  "name": "@side/workflow-status-notification-action",
   "version": "0.0.0-development",
   "description": "Github Action workflow failure/success notification.",
   "main": "dist/index.js",
@@ -11,11 +11,11 @@
     "build": "rimraf dist && ncc build src/index.ts && ts-node bin/generate-docs.ts",
     "lint": "eslint . --ignore-pattern='!.eslintrc.js' --ext .ts,.js",
     "types": "tsc --noEmit",
-    "test": "export GITHUB_REPOSITORY='reside-eng/workflow-status-slack-notification' && yarn tsc && jest"
+    "test": "export GITHUB_REPOSITORY='reside-eng/workflow-status-notification-action' && yarn tsc && jest"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/reside-eng/workflow-status-slack-notification"
+    "url": "https://github.com/reside-eng/workflow-status-notification-action"
   },
   "keywords": [
     "actions",

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -55,7 +55,7 @@ function setupMock() {
     },
     repo: {
       owner: 'reside-eng',
-      repo: 'workflow-status-slack-notification',
+      repo: 'workflow-status-notification-action',
     },
     workflow: 'Failure workflow (for test purpose only)',
     prNumber: 4,
@@ -146,7 +146,7 @@ describe('last run status retrieved from cache (re-run workflow behavior)', () =
                 Object {
                   "short": true,
                   "title": "Repository",
-                  "value": "workflow-status-slack-notification",
+                  "value": "workflow-status-notification-action",
                 },
                 Object {
                   "short": true,
@@ -156,7 +156,7 @@ describe('last run status retrieved from cache (re-run workflow behavior)', () =
                 Object {
                   "short": true,
                   "title": "Action URL",
-                  "value": "<https://github.com/reside-eng/workflow-status-slack-notification/actions/runs/23456|Failure workflow (for test purpose only)>",
+                  "value": "<https://github.com/reside-eng/workflow-status-notification-action/actions/runs/23456|Failure workflow (for test purpose only)>",
                 },
                 Object {
                   "short": true,
@@ -166,7 +166,7 @@ describe('last run status retrieved from cache (re-run workflow behavior)', () =
                 Object {
                   "short": false,
                   "title": "Failure workflow (for test purpose only) workflow success",
-                  "value": "Previously failing Failure workflow (for test purpose only) workflow in workflow-status-slack-notification succeeded.",
+                  "value": "Previously failing Failure workflow (for test purpose only) workflow in workflow-status-notification-action succeeded.",
                 },
               ],
             },
@@ -204,7 +204,7 @@ describe('last run status retrieved from cache (re-run workflow behavior)', () =
                 Object {
                   "short": true,
                   "title": "Repository",
-                  "value": "workflow-status-slack-notification",
+                  "value": "workflow-status-notification-action",
                 },
                 Object {
                   "short": true,
@@ -214,7 +214,7 @@ describe('last run status retrieved from cache (re-run workflow behavior)', () =
                 Object {
                   "short": true,
                   "title": "Action URL",
-                  "value": "<https://github.com/reside-eng/workflow-status-slack-notification/actions/runs/23456|Failure workflow (for test purpose only)>",
+                  "value": "<https://github.com/reside-eng/workflow-status-notification-action/actions/runs/23456|Failure workflow (for test purpose only)>",
                 },
                 Object {
                   "short": true,
@@ -224,7 +224,7 @@ describe('last run status retrieved from cache (re-run workflow behavior)', () =
                 Object {
                   "short": false,
                   "title": "Failure workflow (for test purpose only) workflow failure",
-                  "value": "Failure workflow (for test purpose only) workflow in workflow-status-slack-notification failed.",
+                  "value": "Failure workflow (for test purpose only) workflow in workflow-status-notification-action failed.",
                 },
               ],
             },
@@ -265,7 +265,7 @@ describe('last run status retrieved from cache (re-run workflow behavior)', () =
                 Object {
                   "short": true,
                   "title": "Repository",
-                  "value": "workflow-status-slack-notification",
+                  "value": "workflow-status-notification-action",
                 },
                 Object {
                   "short": true,
@@ -275,7 +275,7 @@ describe('last run status retrieved from cache (re-run workflow behavior)', () =
                 Object {
                   "short": true,
                   "title": "Action URL",
-                  "value": "<https://github.com/reside-eng/workflow-status-slack-notification/actions/runs/23456|Failure workflow (for test purpose only)>",
+                  "value": "<https://github.com/reside-eng/workflow-status-notification-action/actions/runs/23456|Failure workflow (for test purpose only)>",
                 },
                 Object {
                   "short": true,
@@ -285,7 +285,7 @@ describe('last run status retrieved from cache (re-run workflow behavior)', () =
                 Object {
                   "short": false,
                   "title": "Failure workflow (for test purpose only) workflow success",
-                  "value": "Previously failing Failure workflow (for test purpose only) workflow in workflow-status-slack-notification succeeded.",
+                  "value": "Previously failing Failure workflow (for test purpose only) workflow in workflow-status-notification-action succeeded.",
                 },
               ],
             },
@@ -320,7 +320,7 @@ describe('last run status retrieved from GH CLI (new commit workflow behavior)',
                 Object {
                   "short": true,
                   "title": "Repository",
-                  "value": "workflow-status-slack-notification",
+                  "value": "workflow-status-notification-action",
                 },
                 Object {
                   "short": true,
@@ -330,7 +330,7 @@ describe('last run status retrieved from GH CLI (new commit workflow behavior)',
                 Object {
                   "short": true,
                   "title": "Action URL",
-                  "value": "<https://github.com/reside-eng/workflow-status-slack-notification/actions/runs/23456|Failure workflow (for test purpose only)>",
+                  "value": "<https://github.com/reside-eng/workflow-status-notification-action/actions/runs/23456|Failure workflow (for test purpose only)>",
                 },
                 Object {
                   "short": true,
@@ -340,7 +340,7 @@ describe('last run status retrieved from GH CLI (new commit workflow behavior)',
                 Object {
                   "short": false,
                   "title": "Failure workflow (for test purpose only) workflow success",
-                  "value": "Previously failing Failure workflow (for test purpose only) workflow in workflow-status-slack-notification succeeded.",
+                  "value": "Previously failing Failure workflow (for test purpose only) workflow in workflow-status-notification-action succeeded.",
                 },
               ],
             },
@@ -381,7 +381,7 @@ describe('last run status retrieved from GH CLI (new commit workflow behavior)',
                 Object {
                   "short": true,
                   "title": "Repository",
-                  "value": "workflow-status-slack-notification",
+                  "value": "workflow-status-notification-action",
                 },
                 Object {
                   "short": true,
@@ -391,7 +391,7 @@ describe('last run status retrieved from GH CLI (new commit workflow behavior)',
                 Object {
                   "short": true,
                   "title": "Action URL",
-                  "value": "<https://github.com/reside-eng/workflow-status-slack-notification/actions/runs/23456|Success workflow (for test purpose only)>",
+                  "value": "<https://github.com/reside-eng/workflow-status-notification-action/actions/runs/23456|Success workflow (for test purpose only)>",
                 },
                 Object {
                   "short": true,
@@ -401,7 +401,7 @@ describe('last run status retrieved from GH CLI (new commit workflow behavior)',
                 Object {
                   "short": false,
                   "title": "Success workflow (for test purpose only) workflow failure",
-                  "value": "Success workflow (for test purpose only) workflow in workflow-status-slack-notification failed.",
+                  "value": "Success workflow (for test purpose only) workflow in workflow-status-notification-action failed.",
                 },
               ],
             },
@@ -441,7 +441,7 @@ describe('last run status retrieved from GH CLI (new commit workflow behavior)',
                 Object {
                   "short": true,
                   "title": "Repository",
-                  "value": "workflow-status-slack-notification",
+                  "value": "workflow-status-notification-action",
                 },
                 Object {
                   "short": true,
@@ -451,7 +451,7 @@ describe('last run status retrieved from GH CLI (new commit workflow behavior)',
                 Object {
                   "short": true,
                   "title": "Action URL",
-                  "value": "<https://github.com/reside-eng/workflow-status-slack-notification/actions/runs/23456|Failure workflow (for test purpose only)>",
+                  "value": "<https://github.com/reside-eng/workflow-status-notification-action/actions/runs/23456|Failure workflow (for test purpose only)>",
                 },
                 Object {
                   "short": true,
@@ -461,7 +461,7 @@ describe('last run status retrieved from GH CLI (new commit workflow behavior)',
                 Object {
                   "short": false,
                   "title": "Failure workflow (for test purpose only) workflow success",
-                  "value": "Previously failing Failure workflow (for test purpose only) workflow in workflow-status-slack-notification succeeded.",
+                  "value": "Previously failing Failure workflow (for test purpose only) workflow in workflow-status-notification-action succeeded.",
                 },
               ],
             },


### PR DESCRIPTION
We are renaming this action in order to follow the naming convention for our custom actions and make the naming more generic for possible future extensions/changes related to the services we want to notify.