### PR TITLE
fix(security): pin third-party GitHub Actions to immutable SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
@@ -55,7 +55,7 @@ jobs:
           git restore .yarnrc.yml
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@5982a02995853159735cb838992248c4f0f16166 # v2.7.0
         id: semantic
         with:
           # TMP: We're fixing @semantic-release/github version because 8.0.9 is causing an unexpected issue: https://github.com/semantic-release/github/issues/642
@@ -99,9 +99,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: technote-space/workflow-conclusion-action@v3.0.3
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
 
       - uses: reside-eng/workflow-status-notification-action@v1
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
@@ -51,9 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: technote-space/workflow-conclusion-action@v3.0.3
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
 
       - uses: reside-eng/workflow-status-notification-action@v1
         with:


### PR DESCRIPTION
## Summary

Pin every third-party GitHub Action to an immutable commit SHA (with a version comment so Renovate can still manage updates). First-party reside-eng/* references are deliberately left on their floating tag.

Per GitHub security guidance, pinning to a full-length commit SHA is currently the only way to use an action as an immutable release. The trailing `# vX.Y.Z` comment is what Renovate reads to bump both the SHA and the version together on new releases.

## Pinned SHA refs

```
actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
cycjimmy/semantic-release-action@5982a02995853159735cb838992248c4f0f16166 # v2.7.0
technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
```

## Test plan

- [ ] CI passes on this PR
