### PR TITLE
chore: align repo baseline (CODEOWNERS v4, MQ-aware verify, baseline workflows)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,14 @@
 * @reside-eng/platform-tools
-
-# Skip assigning dep updates (handled by Renovate)
+# ownerless carve-outs (last-match-wins): bot-flow paths — any write-access approval suffices
+.github/
 package.json
 yarn.lock
+.yarn/
+.yarnrc.yml
+# github-action extra: Renovate postUpgradeTasks rebuild dist/ on every npm PR
+dist/
+# re-owned sensitive meta files (must come after the carve-outs)
+.github/CODEOWNERS @reside-eng/devops
+.github/renovate.json @reside-eng/devops
+.github/renovate.json5 @reside-eng/devops
+renovate.json @reside-eng/devops

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,25 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  actions: write
+  contents: write
+  deployments: write
+  id-token: write
+  issues: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  claude:
+    uses: reside-eng/workflow-templates-library/.github/workflows/claude-code.yml@v1
+    secrets: inherit

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,21 @@
+name: PR code Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: write
+  deployments: write
+  id-token: write
+  issues: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  code-review:
+    uses: reside-eng/workflow-templates-library/.github/workflows/code-review.yml@v1
+    secrets: inherit

--- a/.github/workflows/request-devops-review.yml
+++ b/.github/workflows/request-devops-review.yml
@@ -1,0 +1,13 @@
+name: Request DevOps Review
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+      - '.yarnrc.yml'
+      - '.yarn/**'
+
+jobs:
+  request-devops-review:
+    uses: reside-eng/workflow-templates-library/.github/workflows/request-devops-review.yml@v1
+    secrets: inherit

--- a/.github/workflows/verify-pr-format.yml
+++ b/.github/workflows/verify-pr-format.yml
@@ -1,0 +1,26 @@
+name: Verify PR format
+
+on:
+  pull_request:
+    branches:
+      - main
+      - next
+      - next-major
+      - alpha
+      - beta
+      # N.x (maintenance release branches)
+      - '[0-9]+.x'
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  build:
+    name: Verify PR title
+    uses: reside-eng/workflow-templates-library/.github/workflows/verify-pr-title.yml@v1
+    with:
+      WORKFLOW_NAME: Verify PR title

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,10 +1,13 @@
 name: Verify
 
-on: [pull_request]
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
-  group: verify-${{ github.head_ref }}
-  cancel-in-progress: true
+  group: verify-${{ github.event_name == 'merge_group' && github.ref || github.head_ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 env:
   NODE_VERSION: 24.x
@@ -14,32 +17,59 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare environment
+        id: prepare-env
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
+            echo "IN_MERGE_QUEUE=true" >> $GITHUB_ENV
+            temp_name=${GITHUB_REF_NAME#gh-readonly-queue/main/pr-}
+            pr_number="${temp_name%-*}"
+            echo "PR_NUMBER=${pr_number}" >> $GITHUB_ENV
+          else
+            echo "IN_MERGE_QUEUE=false" >> $GITHUB_ENV
+            echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          fi
+
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # Skip decision at step level so the required 'build' context always reports
+      - name: Check if PR already up-to-date
+        id: mq-check-pr-uptodate
+        uses: reside-eng/workflow-templates-library/.github/actions/mq-check-uptodate@v1
+        with:
+          github-token: ${{ github.token }}
+          pr-number: ${{ env.PR_NUMBER }}
+
       - name: Use Node.js ${{ env.NODE_VERSION }}
+        if: env.IN_MERGE_QUEUE != 'true' || env.PR_UPTODATE != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
 
       - name: Install dependencies
+        if: env.IN_MERGE_QUEUE != 'true' || env.PR_UPTODATE != 'true'
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_READ_TOKEN }}
         run: yarn install --immutable
 
       - name: Check
+        if: env.IN_MERGE_QUEUE != 'true' || env.PR_UPTODATE != 'true'
         run: yarn check
 
       - name: Check types
+        if: env.IN_MERGE_QUEUE != 'true' || env.PR_UPTODATE != 'true'
         run: yarn types:check
 
       - name: Test
+        if: env.IN_MERGE_QUEUE != 'true' || env.PR_UPTODATE != 'true'
         run: yarn test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
+        if: env.IN_MERGE_QUEUE != 'true' || env.PR_UPTODATE != 'true'
         run: yarn build
 
   notification:

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## What

Adopts the org repo-config baseline. No application code touched.

- **CODEOWNERS** rewritten to the agreed skeleton: `*` catch-all → ownerless bot-flow carve-outs → sensitive meta files re-owned by `@reside-eng/devops` (order matters: CODEOWNERS is last-match-wins).
- **`request-devops-review`** consumer added — requests `@reside-eng/devops` review on human PRs touching sensitive paths, while skipping bot authors so Renovate keeps auto-merging.
- plus the per-repo items listed in the commit body.

## ⚠️ One decision to confirm: `.yarnrc.yml`

The baseline makes `.yarnrc.yml` an **ownerless carve-out**, which removes the explicit `.yarnrc.yml @reside-eng/devops` rule this repo has today (30 repos are affected org-wide).

That carve-out is genuinely required: Renovate's `chore(deps): update yarn to vX` PRs **do** rewrite `.yarnrc.yml` (the `yarnPath:` line), so keeping devops as code owner would block those from auto-merging.

But `.yarnrc.yml` holds more than `yarnPath` — it also holds our supply-chain policy:

```yaml
npmMinimalAgeGate: 14d          # blocks packages younger than 14 days
npmPreapprovedPackages: [...]   # the allow-list that BYPASSES that gate
```

Fully ownerless means anyone with write access could widen that allow-list or repoint `yarnPath` with no devops review.

**Applied resolution** — your own `.github/` precedent, reused verbatim: keep it ownerless (so Renovate automerges), and extend the `request-devops-review` path filter to cover it, so **human** edits still pull in devops:

```yaml
on:
  pull_request:
    paths:
      - '.github/**'
      - '.yarnrc.yml'
      - '.yarn/**'
```

Like `.github/`, this is a review *request*, not a hard gate. Say the word if you'd rather have `.yarnrc.yml` re-owned by devops (hard gate, yarn bumps stop auto-merging) and I'll flip it across the wave.

---
**This is the sign-off golden for its wave.** The remaining repos in the wave are staged locally and will only be opened once this is approved.
